### PR TITLE
use @static to silence warnings in v0.6

### DIFF
--- a/src/array_partition.jl
+++ b/src/array_partition.jl
@@ -35,7 +35,7 @@ Base.:*(A::ArrayPartition, B::Number) = ArrayPartition((x .* B for x in A.x)...)
 Base.:/(A::ArrayPartition, B::Number) = ArrayPartition((x ./ B for x in A.x)...)
 Base.:\(A::Number, B::ArrayPartition) = ArrayPartition((x ./ A for x in B.x)...)
 
-if VERSION < v"0.6-"
+@static if VERSION < v"0.6-"
   Base.:.+(A::ArrayPartition, B::ArrayPartition) = ArrayPartition((x .+ y for (x,y) in zip(A.x,B.x))...)
   Base.:.+(A::Number, B::ArrayPartition) = ArrayPartition((A .+ x for x in B.x)...)
   Base.:.+(A::ArrayPartition, B::Number) = ArrayPartition((B .+ x for x in A.x)...)


### PR DESCRIPTION
Without `@static` these definitions still result in deprecation warnings on v0.6. 