### PR TITLE
recursivecopy! for StaticArrays

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,7 +8,8 @@ end
 
 function recursivecopy!{T<:StaticArray,N}(b::AbstractArray{T,N},a::AbstractArray{T,N})
   @inbounds for i in eachindex(a)
-    b[i] = a[i]
+    # TODO: Check for `setindex!`` and use `copy!(b[i],a[i])` or `b[i] = a[i]`, see #19
+    b[i] = copy(a[i])
   end
 end
 

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -1,0 +1,42 @@
+using Base.Test, RecursiveArrayTools, StaticArrays
+
+struct ImmutableFV <: FieldVector{2,Float64}
+    a::Float64
+    b::Float64
+end
+
+mutable struct MutableFV <: FieldVector{2,Float64}
+    a::Float64
+    b::Float64
+end
+
+# Immutable FieldVector
+vec = ImmutableFV(1.,2.)
+a = [vec]
+b = zeros(a)
+recursivecopy!(b, a)
+@test a[1] == b[1]
+
+# Mutable FieldVector
+vec = MutableFV(1.,2.)
+a = [vec]
+b = zeros(a)
+recursivecopy!(b, a)
+@test a[1] == b[1]
+a[1][1] *= 5
+@test a[1] != b[1]
+
+# SArray
+vec = @SArray [1., 2.]
+a = [vec]
+b = zeros(a)
+recursivecopy!(b, a)
+@test a[1] == b[1]
+
+# MArray
+vec = @MArray [1., 2.]
+a = [vec]
+b = zeros(a)
+recursivecopy!(b, a)
+a[1][1] *= 5
+@test a[1] != b[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,5 +7,6 @@ tic()
 @time @testset "Partitions Tests" begin include("partitions_test.jl") end
 @time @testset "VecOfArr Indexing Tests" begin include("basic_indexing.jl") end
 @time @testset "VecOfArr Interface Tests" begin include("interface_tests.jl") end
+@time @testset "StaticArrays (recursivecopy!) Tests" begin include("copy_static_array_test.jl") end
 toc()
 # Test the VectorOfArray code


### PR DESCRIPTION
`recursivecopy!`now uses `copy` for `StaticArray`s, see #19. This should be correct for both mutable and immutable `StaticArray`s, but performance could probably be improved for mutable ones if `copy!` can be used.

Could you please release a new version `v0.12.2` of `RecursiveArrayTools` including this fix?