### PR TITLE
fix copyat_or_push! for StaticArrays

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -52,7 +52,9 @@ end
 
 @inline function copyat_or_push!{T,perform_copy}(a::AbstractVector{T},i::Int,x,nc::Type{Val{perform_copy}}=Val{true})
   @inbounds if length(a) >= i
-    if T <: Number || !perform_copy
+    if T <: Number || T <: StaticArray || !perform_copy
+      # TODO: Check for `setindex!`` if T <: StaticArray and use `copy!(b[i],a[i])`
+      #       or `b[i] = a[i]`, see #19
       a[i] = x
     else
       recursivecopy!(a[i],x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,12 @@
+"""
+    is_mutable_type(x::DataType)
+
+Query whether a type is mutable or not, see
+https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19.
+"""
+Base.@pure is_mutable_type(x::DataType) = x.mutable
+
+
 function recursivecopy{T<:Number,N}(a::AbstractArray{T,N})
   copy(a)
 end
@@ -52,9 +61,9 @@ end
 
 @inline function copyat_or_push!{T,perform_copy}(a::AbstractVector{T},i::Int,x,nc::Type{Val{perform_copy}}=Val{true})
   @inbounds if length(a) >= i
-    if T <: Number || T <: StaticArray || !perform_copy
+    if T <: Number || T <: SArray || (T <: FieldVector && !is_mutable_type(T)) || !perform_copy
       # TODO: Check for `setindex!`` if T <: StaticArray and use `copy!(b[i],a[i])`
-      #       or `b[i] = a[i]`, see #19
+      #       or `b[i] = a[i]`, see https://github.com/JuliaDiffEq/RecursiveArrayTools.jl/issues/19
       a[i] = x
     else
       recursivecopy!(a[i],x)

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -32,6 +32,8 @@ a[1][1] *= 5
 @test a[1] != b[1]
 copyat_or_push!(a, 2, b[1])
 @test a[2] == b[1]
+a[2][1] *= 5
+@test a[2] != b[1]
 b[1] = 2*b[1]
 copyat_or_push!(a, 2, b[1])
 @test a[2] == b[1]
@@ -57,6 +59,8 @@ a[1][1] *= 5
 @test a[1] != b[1]
 copyat_or_push!(a, 2, b[1])
 @test a[2] == b[1]
+a[2][1] *= 5
+@test a[2] != b[1]
 b[1] = 2*b[1]
 copyat_or_push!(a, 2, b[1])
 @test a[2] == b[1]

--- a/test/copy_static_array_test.jl
+++ b/test/copy_static_array_test.jl
@@ -16,6 +16,11 @@ a = [vec]
 b = zeros(a)
 recursivecopy!(b, a)
 @test a[1] == b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
+b[1] = 2*b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
 
 # Mutable FieldVector
 vec = MutableFV(1.,2.)
@@ -25,6 +30,11 @@ recursivecopy!(b, a)
 @test a[1] == b[1]
 a[1][1] *= 5
 @test a[1] != b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
+b[1] = 2*b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
 
 # SArray
 vec = @SArray [1., 2.]
@@ -32,6 +42,11 @@ a = [vec]
 b = zeros(a)
 recursivecopy!(b, a)
 @test a[1] == b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
+b[1] = 2*b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
 
 # MArray
 vec = @MArray [1., 2.]
@@ -40,3 +55,8 @@ b = zeros(a)
 recursivecopy!(b, a)
 a[1][1] *= 5
 @test a[1] != b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]
+b[1] = 2*b[1]
+copyat_or_push!(a, 2, b[1])
+@test a[2] == b[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,6 @@ tic()
 @time @testset "Partitions Tests" begin include("partitions_test.jl") end
 @time @testset "VecOfArr Indexing Tests" begin include("basic_indexing.jl") end
 @time @testset "VecOfArr Interface Tests" begin include("interface_tests.jl") end
-@time @testset "StaticArrays (recursivecopy!) Tests" begin include("copy_static_array_test.jl") end
+@time @testset "StaticArrays Tests" begin include("copy_static_array_test.jl") end
 toc()
 # Test the VectorOfArray code


### PR DESCRIPTION
This fixes some problems for OrdinaryDiffEq with callbacks if `u <: StaticArray`.