### PR TITLE
Base.similar and Base.fill! for VectorOfArray

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -61,6 +61,22 @@ function Base.append!{T, N}(VA::AbstractVectorOfArray{T, N}, new_item::AbstractV
     return VA
 end
 
+# Tools for creating similar objects
+@inline Base.similar(VA::VectorOfArray{T}) where {T} = similar(VA, T)
+@inline Base.similar(VA::VectorOfArray, ::Type{T}) where {T} = VectorOfArray([similar(VA[i], T) for i in eachindex(VA)])
+
+# fill!
+# For DiffEqArray it ignores ts and fills only u
+function Base.fill!(VA::AbstractVectorOfArray, x)
+    for i in eachindex(VA)
+        fill!(VA[i], x)
+    end
+    return VA
+end
+
+# Need this for ODE_DEFAULT_UNSTABLE_CHECK from DiffEqBase to work properly
+@inline Base.any(f, VA::AbstractVectorOfArray) = any(any(f,VA[i]) for i in eachindex(VA))
+
 # conversion tools
 @deprecate vecarr_to_arr(VA::AbstractVectorOfArray) convert(Array,VA)
 @deprecate vecarr_to_arr{T<:AbstractArray}(VA::Vector{T}) convert(Array,VA)

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -62,8 +62,7 @@ function Base.append!{T, N}(VA::AbstractVectorOfArray{T, N}, new_item::AbstractV
 end
 
 # Tools for creating similar objects
-@inline Base.similar(VA::VectorOfArray{T}) where {T} = similar(VA, T)
-@inline Base.similar(VA::VectorOfArray, ::Type{T}) where {T} = VectorOfArray([similar(VA[i], T) for i in eachindex(VA)])
+@inline Base.similar(VA::VectorOfArray, ::Type{T} = eltype(VA)) where {T} = VectorOfArray([similar(VA[i], T) for i in eachindex(VA)])
 
 # fill!
 # For DiffEqArray it ignores ts and fills only u

--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -75,6 +75,7 @@ end
 
 # Need this for ODE_DEFAULT_UNSTABLE_CHECK from DiffEqBase to work properly
 @inline Base.any(f, VA::AbstractVectorOfArray) = any(any(f,VA[i]) for i in eachindex(VA))
+@inline Base.all(f, VA::AbstractVectorOfArray) = all(all(f,VA[i]) for i in eachindex(VA))
 
 # conversion tools
 @deprecate vecarr_to_arr(VA::AbstractVectorOfArray) convert(Array,VA)

--- a/test/interface_tests.jl
+++ b/test/interface_tests.jl
@@ -42,3 +42,29 @@ testa = cat(3, recs...)
 recs = [[1, 2, 3], [3 5; 6 7], [8, 9, 10, 11]]
 testva = VectorOfArray(recs)
 @test size(convert(Array,testva)) == (3,3)
+
+# create similar VectorOfArray
+recs = [rand(6) for i = 1:4]
+testva = VectorOfArray(recs)
+testva2 = similar(testva)
+@test typeof(testva2) == typeof(testva)
+@test size(testva2) == size(testva)
+
+# Fill AbstractVectorOfArray and check all
+testval = 3.0
+fill!(testva2, testval)
+@test all(x->(x==testval), testva2)
+testts = rand(size(testva.u))
+testda = DiffEqArray(recursivecopy(testva.u), testts)
+fill!(testda, testval)
+@test all(x->(x==testval), testda)
+
+# check any
+recs = [collect(1:5), collect(6:10), collect(11:15)]
+testts = rand(5)
+testva = VectorOfArray(recs)
+testda = DiffEqArray(recs, testts)
+testval1 = 4
+testval2 = 17
+@test any(x->(x==testval1), testva)
+@test !any(x->(x==testval2), testda)


### PR DESCRIPTION
This PR is addressing #23.
I've added dispatch on VectorOfArray for Base.similar

I didn't do it for DiffEqArray. As I understand, DiffEqArray is used to store the results, so do we really need to use similar with it?

I've added dispatch on AbstractVectorOfArray for Base.fill!
For DiffEqArray it ignores ts and just fills u.
Now we can use zeros and ones with VectorOfArray.

I also fixed any(f, itr) for AbstractVectorOfArray. Now ODE_DEFAULT_UNSTABLE_CHECK from DiffEqBase works properly with AbstractVectorOfArray.
I suppose I should have done separate PR for it, but the change is small.