### PR TITLE
Add getindex(::VofA, ::Colon, ::Int)

### DIFF
--- a/src/vector_of_array.jl
+++ b/src/vector_of_array.jl
@@ -40,6 +40,7 @@ end
 # Interface for the two dimensional indexing, a more standard AbstractArray interface
 @inline Base.size(VA::AbstractVectorOfArray) = (size(VA.u[1])..., length(VA.u))
 @inline Base.getindex{T, N}(VA::AbstractVectorOfArray{T, N}, I::Int...) = VA.u[I[end]][Base.front(I)...]
+@inline Base.getindex{T, N}(VA::AbstractVectorOfArray{T, N}, ::Colon, I::Int) = VA.u[I]
 @inline Base.setindex!{T, N}(VA::AbstractVectorOfArray{T, N}, v, I::Int...) = VA.u[I[end]][Base.front(I)...] = v
 
 # The iterator will be over the subarrays of the container, not the individual elements


### PR DESCRIPTION
This PR causes "matrix getindex" with a colon in the first place to return the unmodified underlying AbstractVector. Tests pass, bu I can potentially imagine unexpected behaviour if the internal AbstractArray is multidimensional. If problems like these are sorted out, I think it's nice to be able to get back, e.g., an `SVector` without having it converted to a standard `Array`
```julia
julia> using RecursiveArrayTools, StaticArrays

julia> s1 = SVector(1,2);

julia> s2 = SVector(3,4);

julia> a = VectorOfArray([s1,s2])
VectorOfArray{Int64,2}
u:
2-element Array{SVector{2,Int64},1}:
 [1, 2]
 [3, 4]

# Old behaviour
julia> a[:,2]
2-element Array{Int64,1}:
 3
 4

# New behaviour
julia> a[:,2]
2-element SVector{2,Int64}:
 3
 4
```