### PR TITLE
No deep copy for numbers

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -10,6 +10,8 @@ function recursivecopy(a)
   deepcopy(a)
 end
 
+recursivecopy(a::Number) = copy(a)
+
 function recursivecopy(a::AbstractArray{T,N}) where {T<:Number,N}
   copy(a)
 end


### PR DESCRIPTION
As discussed in https://github.com/JuliaDiffEq/DelayDiffEq.jl/pull/95#discussion_r249277410. Tests with Measurements.jl in PuMaS still succeed. Is there anything else that should be tested prior to merging?