### PR TITLE
Type agnostic, finite recursive_bottom_eltype function

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,8 +76,7 @@ end
 recursive_one(a) = recursive_one(a[1])
 recursive_one(a::T) where {T<:Number} = one(a)
 
-recursive_bottom_eltype(a) = recursive_bottom_eltype(eltype(a))
-recursive_bottom_eltype(a::Type{T}) where {T<:Number} = eltype(a)
+recursive_bottom_eltype(a) = a == eltype(a) ? a : recursive_bottom_eltype(eltype(a))
 
 recursive_unitless_bottom_eltype(a) = recursive_unitless_bottom_eltype(typeof(a))
 recursive_unitless_bottom_eltype(a::Type{T}) where T = recursive_unitless_bottom_eltype(eltype(a))

--- a/test/utils_test.jl
+++ b/test/utils_test.jl
@@ -30,3 +30,42 @@ recursive_unitless_eltype(AofuSA) == SVector{2,Float64}
 
 A = [ArrayPartition(ones(1),ones(1)),]
 @test repr("text/plain", A) == "1-element Array{ArrayPartition{Float64,Tuple{Array{Float64,1},Array{Float64,1}}},1}:\n [1.0][1.0]"
+
+function test_recursive_bottom_eltype()
+  function test_value(val::Any, expected_type::Type)
+    # It should return the expected type for the given expected type
+    @test recursive_bottom_eltype(expected_type) == expected_type
+
+    # It should return the expected type for the given value
+    @test recursive_bottom_eltype(val) == expected_type
+
+    # It should return the expected type for an array of the given value
+    Aval = [val for i in 1:5]
+    @test recursive_bottom_eltype(Aval) == expected_type
+
+    # It should return expected type for a nested array of the gicen value
+    AAval = [Aval for i in 1:5]
+    @test recursive_bottom_eltype(AAval) == expected_type
+
+    # It should return expected type for an array of vectors of chars
+    AVval = [@SVector [val, val] for i in 1:5]
+    @test recursive_bottom_eltype(AVval) == expected_type
+  end
+
+  # testing chars
+  test_value('c', Char)
+
+  # testing strings
+  # We expect recursive_bottom_eltype to return `Char` for a string, because
+  # `eltype("Some String") == Char`
+  test_value("Some String", Char)
+
+  # testing integer values
+  test_value(1, Int)
+  test_value(1u"kg", eltype(1u"kg"))
+
+  # testing float values
+  test_value(1.0, Float64)
+  test_value(1.0u"kg", eltype(1.0u"kg"))
+end
+test_recursive_bottom_eltype()


### PR DESCRIPTION
Before the `recursive_bottom_eltype` function was written with only
numeric types in mind. For those, it worked. But for non-numeric types
it recused infinitely, causing a `StackOverflowError`.
Now it works on any type and is sure to recurse only a finite number of
time, thus always end and return a result.
The recursion ends, when the given argument `a` is the same as `eltype(a)`. So, as there is a limited amount of types in Julia, we will only recurse a limited amount of times.

I also added tests that cover this specific function, testing numbers
with and without units as well as chars and strings.